### PR TITLE
Added endpoints for generating and paying payment links

### DIFF
--- a/config.go
+++ b/config.go
@@ -209,10 +209,11 @@ func GetMainEngine() *gin.Engine {
 		cons.DELETE("/delete_card", consumerService.RemoveCard)
 		cons.GET("/payment_token", consumerService.GetPaymentToken)
 		cons.POST("/payment_token", consumerService.GeneratePaymentToken)
+		cons.POST("/payment_token/quick_pay", consumerService.NoebsQuickPayment)
 		cons.POST("/payment_link", func(ctx *gin.Context) {
 			consumerService.GeneratePaymentLink(ctx, noebsConfig.PaymentLinkBase)
 		})
-		cons.POST("/payment_token/quick_pay", consumerService.NoebsQuickPayment)
+		cons.POST("/pay/:uuid", consumerService.PayPaymentLink)
 	}
 	return route
 }

--- a/config.go
+++ b/config.go
@@ -176,8 +176,8 @@ func GetMainEngine() *gin.Engine {
 		cons.GET("/users/cards", gin.HandlerFunc(func(ctx *gin.Context) {
 			mobile := ctx.Query("mobile")
 			if response, err := ebs_fields.GetCardsOrFail(mobile, database); err != nil {
-					ctx.JSON(http.StatusBadRequest, gin.H{"code": "not_found", "message": err.Error()})
-					return
+				ctx.JSON(http.StatusBadRequest, gin.H{"code": "not_found", "message": err.Error()})
+				return
 			} else {
 				ctx.JSON(http.StatusOK, response)
 			}
@@ -209,6 +209,9 @@ func GetMainEngine() *gin.Engine {
 		cons.DELETE("/delete_card", consumerService.RemoveCard)
 		cons.GET("/payment_token", consumerService.GetPaymentToken)
 		cons.POST("/payment_token", consumerService.GeneratePaymentToken)
+		cons.POST("/payment_link", func(ctx *gin.Context) {
+			consumerService.GeneratePaymentLink(ctx, noebsConfig.PaymentLinkBase)
+		})
 		cons.POST("/payment_token/quick_pay", consumerService.NoebsQuickPayment)
 	}
 	return route

--- a/ebs_fields/fields.go
+++ b/ebs_fields/fields.go
@@ -236,9 +236,6 @@ func iso8601(fl validator.FieldLevel) bool {
 	return err == nil
 }
 
-
-
-
 // EBSResponse represent a struct that captures all of EBS response fields and map them into Transaction table
 // We should really split this up between consumer and merchant. It is just too complicated to manage now
 type EBSResponse struct {
@@ -277,10 +274,10 @@ type EBSResponse struct {
 	AdditionalData       string          `json:"additionalData,omitempty"`
 	TranDateTime         string          `json:"tranDateTime,omitempty"`
 	TranFee              *float32        `json:"tranFee,omitempty"`
-	AdditionalAmount *float32 `json:"additionalAmount,omitempty"`
-	AcqTranFee       *float32 `json:"acqTranFee,omitempty"`
-	IssTranFee       *float32 `json:"issuerTranFee,omitempty"`
-	TranCurrency     string   `json:"tranCurrency,omitempty"`
+	AdditionalAmount     *float32        `json:"additionalAmount,omitempty"`
+	AcqTranFee           *float32        `json:"acqTranFee,omitempty"`
+	IssTranFee           *float32        `json:"issuerTranFee,omitempty"`
+	TranCurrency         string          `json:"tranCurrency,omitempty"`
 
 	// QR payment fields
 	MerchantID               string  `json:"merchantID,omitempty"`
@@ -346,7 +343,7 @@ func (e EBSResponse) GetEBSUUID(originalUUID string, db *gorm.DB, noebsConfig *N
 	fields.ApplicationId = noebsConfig.ConsumerID
 	fields.TranDateTime = EbsDate()
 	fields.OriginalTranUUID = originalUUID
-	uid,_ := uuid.NewRandom()
+	uid, _ := uuid.NewRandom()
 	fields.UUID = uid.String()
 	jsonBuffer, err := json.Marshal(fields)
 	if err != nil {
@@ -379,7 +376,6 @@ type EBSParserFields struct {
 	EBSMapFields
 	EBSResponse
 	OriginalTransaction EBSResponse `json:"originalTransaction,omitempty"`
-	
 }
 
 // To allow Redis to use this struct directly in marshaling
@@ -503,13 +499,12 @@ type ConsumerCommonFields struct {
 	ApplicationId string `json:"applicationId" form:"applicationId" binding:"required"`
 	TranDateTime  string `json:"tranDateTime" form:"tranDateTime" binding:"required"`
 	UUID          string `json:"UUID" form:"UUID" binding:"required"`
-	DeviceID string `json:"device_id,omitempty"`
+	DeviceID      string `json:"device_id,omitempty"`
 }
 
 func (c *ConsumerCommonFields) DelDeviceID() {
 	c.DeviceID = ""
 }
-
 
 type ConsumerBillInquiryFields struct {
 	ConsumerCommonFields
@@ -976,6 +971,9 @@ type NoebsConfig struct {
 
 	// SMS message
 	SMSMessage string `json:"sms_message"`
+
+	// This the base of the link for payment links
+	PaymentLinkBase string `json:"payment_link_base"`
 }
 
 func (n *NoebsConfig) Defaults() {

--- a/ebs_fields/users.go
+++ b/ebs_fields/users.go
@@ -301,7 +301,6 @@ type Token struct {
 	ToCard       string        `json:"toCard,omitempty"`
 	EBSResponses []EBSResponse `json:"transaction,omitempty"`
 	IsPaid       bool          `json:"is_paid"`
-	Link         string        `json:"link"`
 }
 
 type QrData struct {

--- a/ebs_fields/users.go
+++ b/ebs_fields/users.go
@@ -301,6 +301,7 @@ type Token struct {
 	ToCard       string        `json:"toCard,omitempty"`
 	EBSResponses []EBSResponse `json:"transaction,omitempty"`
 	IsPaid       bool          `json:"is_paid"`
+	Link         string        `json:"link"`
 }
 
 type QrData struct {
@@ -460,13 +461,13 @@ type Card struct {
 
 type CacheCards struct {
 	gorm.Model
-	Pan      string `json:"pan" gorm:"uniqueIndex"`
-	Expiry   string `json:"exp_date"`
-	Name     string `json:"name"`
-	Mobile   string `json:"mobile" gorm:"-:all"`
-	Password string `json:"password" gorm:"-:all"`
+	Pan       string `json:"pan" gorm:"uniqueIndex"`
+	Expiry    string `json:"exp_date"`
+	Name      string `json:"name"`
+	Mobile    string `json:"mobile" gorm:"-:all"`
+	Password  string `json:"password" gorm:"-:all"`
 	PublicKey string `json:"user_pubkey" gorm:"-:all"`
-	IsValid  *bool  `json:"is_valid"`
+	IsValid   *bool  `json:"is_valid"`
 }
 
 func (c CacheCards) OverrideField() string {
@@ -485,7 +486,6 @@ func (c CacheCards) NewCardFromCached(id int) Card {
 	}
 }
 
-
 // ExpandCard performs a regex search for the first and last 4 digits of a pan and retrieves the matching pan number
 func ExpandCard(card string, userCards []Card) (string, error) {
 	// You can edit this code!
@@ -502,7 +502,7 @@ func ExpandCard(card string, userCards []Card) (string, error) {
 	for _, v := range userCards {
 		cards = append(cards, v.Pan)
 	}
-	search := card[:4] + ".*"+ card[len(card)-4:] + "$"
+	search := card[:4] + ".*" + card[len(card)-4:] + "$"
 	// Compile the regular expression pattern that matches the search string
 	pattern := regexp.MustCompile(search)
 	// Iterate through the list of strings


### PR DESCRIPTION
- Generating payment links is straight forward, it just generates a payment token and takes that token's UUID and appends it to a base link that we can set in the config file (e.g. `tutipay.com/pay/`) so the total link would be something like `tutipay.com/pay/b4d4d0fc-0dbb-494a-884e-9d059e3da079` and returns it to the user.
- Paying this link is similar to `NoebsQuickPayment`, we extract the token from the UUID in the URL and the information of the person paying from the data sent in the body like any other payment endpoint and perform the transaction.