### PR TITLE
fixed sending notification to user who deleted the card

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build:
+	@go build ./...
+
+run: build
+	@./noebs
+
+test:
+	@go test -v ./...

--- a/ebs_fields/users.go
+++ b/ebs_fields/users.go
@@ -142,7 +142,7 @@ func GetUserByCard(pan string, db *gorm.DB) (User, error) {
 // GetDeviceIDsByPan retrieves device_ids associated to a card number
 func GetDeviceIDsByPan(pan string, db *gorm.DB) ([]string, error) {
 	var results []string
-	err := db.Model(&User{}).Distinct("users.device_id").Joins("left join cards on cards.user_id = users.id").Where("users.device_id != ?", "").Where("cards.pan = ?", pan).Scan(&results)
+	err := db.Model(&User{}).Distinct("users.device_id").Joins("left join cards on cards.user_id = users.id").Where("users.device_id != ?", "").Where("cards.pan = ? and cards.deleted_at is null", pan).Scan(&results)
 	return results, err.Error
 }
 


### PR DESCRIPTION
Before if a user registers a card, then deletes it, they will receive all notifications related to this card. This is annoying because if the user wants notifications about the card they would not have deleted it.
Now if the user deletes a card they will no longer receive notifications related to it.