### PR TITLE
associating notifications to their users

### DIFF
--- a/consumer/helper.go
+++ b/consumer/helper.go
@@ -183,6 +183,7 @@ func (s *Service) Pusher() {
 			} else {
 				data.To = user.DeviceID
 				data.EBSData = ebs_fields.EBSResponse{}
+				data.UserMobile = user.Mobile
 				//Omit association when creating
 				s.Db.Omit(clause.Associations).Create(&data)
 				s.SendPush(data)
@@ -196,6 +197,7 @@ func (s *Service) Pusher() {
 			s.Logger.Printf("error finding user: %v", err)
 		} else {
 			data.To = user.DeviceID
+			data.UserMobile = user.Mobile
 			s.Db.Omit(clause.Associations).Create(&data)
 			s.SendPush(data)
 		}

--- a/consumer/payment_apis.go
+++ b/consumer/payment_apis.go
@@ -279,25 +279,20 @@ func (s *Service) BillPayment(c *gin.Context) {
 		utils.SaveRedisList(s.Redis, username+":all_transactions", &res)
 
 		// Adding BillType and BillTo so that the mobile client can show these fields in transactions history
+		res.EBSResponse.BillTo = res.PaymentInfo
 		switch res.PayeeID {
 		case "0010010001", "0010010003", "0010010005": // telecom top up
-			phone := "0" + res.PaymentInfo[7:]
-			res.EBSResponse.BillType = "telecom_top_up"
-			res.EBSResponse.BillTo = phone
+			res.EBSResponse.BillType = "Telecom TopUp"
 		case "0010010002", "0010010004", "0010010006": // telecom bill payment
-			phone := "0" + res.PaymentInfo[7:]
-			res.EBSResponse.BillType = "telecom_bill_payment"
-			res.EBSResponse.BillTo = phone
+			res.EBSResponse.BillType = "Telecom Bill Payment"
 		case "0010030002", "0010030004": // mohe
-			// FIXME: figure out the form of the response and add it
+			res.EBSResponse.BillType = "Education"
 		case "0010030003": // Customs
-			// FIXME: figure out the form of the response and add it
+			res.EBSResponse.BillType = "Customs"
 		case "0010050001": // e-15
-			// FIXME: figure out the form of the response and add it
+			res.EBSResponse.BillType = "Government E-15"
 		case "0010020001": // electricity
-			meter := res.PaymentInfo[6:]
-			res.EBSResponse.BillType = "electricity"
-			res.EBSResponse.BillTo = meter
+			res.EBSResponse.BillType = "Electricity"
 		}
 
 		if err := s.Db.Table("transactions").Create(&res.EBSResponse); err != nil {

--- a/consumer/types.go
+++ b/consumer/types.go
@@ -217,6 +217,9 @@ type PushData struct {
 	Phone    string `json:"phone"`
 	IsRead   bool   `json:"is_read"`
 	DeviceID string `json:"device_id"`
+
+	// UserMobile identifies which user the notification belogs to
+	UserMobile string `json:"user_mobile"`
 }
 
 func (p *PushData) UpdateIsRead(phone string, db *gorm.DB) {


### PR DESCRIPTION
This PR includes:
- Solving the problem of push notifications not being sent in p2p transactions.
- Saving bill payment info with bill payment transactions so they can appear when queried by the front-end.
- Saving notifications with the user that received the notification through `UserMobile` field.