### PR TITLE
adding user profile feature as well as the ability to update it

### DIFF
--- a/config.go
+++ b/config.go
@@ -209,6 +209,7 @@ func GetMainEngine() *gin.Engine {
 		cons.POST("/check_user", consumerService.CheckUser)
 
 		cons.Use(auth.AuthMiddleware())
+		cons.GET("/user", consumerService.GetUser)
 		cons.GET("/notifications", consumerService.Notifications)
 		cons.GET("/transactions", consumerService.GetTransactions)
 		cons.POST("/p2p_mobile", consumerService.MobileTransfer)

--- a/config.go
+++ b/config.go
@@ -210,6 +210,7 @@ func GetMainEngine() *gin.Engine {
 
 		cons.Use(auth.AuthMiddleware())
 		cons.GET("/user", consumerService.GetUser)
+		cons.PUT("/user", consumerService.UpdateUser)
 		cons.GET("/notifications", consumerService.Notifications)
 		cons.GET("/transactions", consumerService.GetTransactions)
 		cons.POST("/p2p_mobile", consumerService.MobileTransfer)

--- a/consumer/auth.go
+++ b/consumer/auth.go
@@ -203,12 +203,24 @@ func (s *Service) CreateUser(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return
 	}
+	// FIXME: Optimize these checks
 	// Make sure user is unique
 	var tmpUser ebs_fields.User
 	if res := s.Db.Where("mobile = ?", u.Mobile).First(&tmpUser); res.Error == nil {
 		// User already exists
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"message": "User with this mobile number already exists"})
 		return
+	}
+	// Make sure username is unique
+	if u.Username != "" {
+		if res := s.Db.Where("username = ?", u.Username).First(&tmpUser); res.Error == nil {
+			// User already exists
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"message": "User with this username already exists"})
+			return
+		}
+	} else {
+		// Currently we set the username to be the same as the mobile number
+		u.Username = u.Mobile
 	}
 
 	// validate u.Password to include at least one capital letter, one symbol and one number

--- a/consumer/payment_apis.go
+++ b/consumer/payment_apis.go
@@ -443,6 +443,7 @@ func (s *Service) RegisterWithCard(c *gin.Context) {
 	}
 	user := ebs_fields.NewUser(s.Db)
 	user.Mobile = card.Mobile
+	user.Username = card.Mobile
 	user.Fullname = card.Name
 	user.MainCard = card.Pan
 	user.ExpDate = card.Expiry

--- a/consumer/services.go
+++ b/consumer/services.go
@@ -679,3 +679,15 @@ func (s *Service) Notifications(c *gin.Context) {
 	var pushdata PushData
 	pushdata.UpdateIsRead(mobile, s.Db)
 }
+
+// GetUser returns the user profile object for the currently logged in user
+func (s *Service) GetUser(c *gin.Context) {
+	mobile := c.GetString("mobile")
+
+	var profile ebs_fields.UserProfile
+	if res := s.Db.Model(&ebs_fields.User{}).Where("mobile = ?", mobile).First(&profile); res.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": res.Error.Error(), "code": "database_error"})
+		return
+	}
+	c.JSON(http.StatusOK, profile)
+}

--- a/ebs_fields/users.go
+++ b/ebs_fields/users.go
@@ -545,3 +545,7 @@ func ExpandCard(card string, userCards []Card) (string, error) {
 	}
 	return "", errors.New("not able to find a match")
 }
+
+func UpdateUser(user User, db *gorm.DB) error {
+	return db.Where("mobile = ?", user.Mobile).Updates(&user).Error
+}

--- a/ebs_fields/users.go
+++ b/ebs_fields/users.go
@@ -42,6 +42,16 @@ type User struct {
 	ExpDate         string `json:"exp_date" gorm:"column:main_expdate"`
 }
 
+// UserProfile is a subset of the User struct, it contains information that appear in the user profile
+// and which user can change.
+type UserProfile struct {
+	Fullname string `json:"fullname" binding:"required,min=1"`
+	Username string `json:"username" binding:"min=1"`
+	Email    string `json:"email" binding:"email"`
+	Birthday string `json:"birthday"`
+	Gender   string `json:"gender"`
+}
+
 // func (user *User) BeforeSave(tx *gorm.DB) (err error) {
 // 	if user.Password == "" {
 // 		return errors.New("password is empty")

--- a/ebs_fields/users.go
+++ b/ebs_fields/users.go
@@ -20,6 +20,8 @@ type User struct {
 	gorm.Model
 	Password        string `binding:"required,min=8,max=20" json:"password"`
 	Fullname        string `json:"fullname"`
+	Username        string `json:"username"`
+	Gender          string `json:"gender"`
 	Birthday        string `json:"birthday"`
 	Mobile          string `json:"mobile" gorm:"primaryKey;not null;unique;uniqueIndex"`
 	Email           string `json:"email"`


### PR DESCRIPTION
This feature:
- When registering a user through `/register` you can submit all of their related info (username, birthday, gender, and so on).
- New endpoint `/user` allows for both getting and updating user profile info.
- GET request to `/user` would return a user profile object for the currently *logged in* user.
- PUT request to `/user` with the edited user profile object in the body of the request would update the info the currently *logged in* user.
- The user profile JSON looks like this:
```
{
    "fullname": "Mohammed Ahmed",
    "username": "mohammed",
    "email": "mohammed.ahmed@tutipay.com",
    "birthday": "2000-12-10",
    "gender": "Male"
}
```